### PR TITLE
Null check state before determining whether or not to destroy connection...

### DIFF
--- a/src/dotnet/SolutionVersion.cs
+++ b/src/dotnet/SolutionVersion.cs
@@ -5,10 +5,10 @@ using System.Security;
 [assembly: AssemblyDescription("ZooKeeper Client for .NET http://zookeeper.apache.org")]
 [assembly: AssemblyProduct("ZooKeeperNet")]
 [assembly: AssemblyCopyright("Copyright 2007-2012 ewhauser, omwok. - All rights reserved.")]
-[assembly: AssemblyVersion("3.3.4.6")]
-[assembly: AssemblyFileVersion("3.3.4.6")]
+[assembly: AssemblyVersion("3.3.4.7")]
+[assembly: AssemblyFileVersion("3.3.4.7")]
 
-[assembly: AssemblyInformationalVersion("3.3.4.6")]
+[assembly: AssemblyInformationalVersion("3.3.4.7")]
 [assembly: ComVisibleAttribute(false)]
 [assembly: CLSCompliantAttribute(false)]
 

--- a/src/dotnet/ZooKeeperNet/ZooKeeper.cs
+++ b/src/dotnet/ZooKeeperNet/ZooKeeper.cs
@@ -385,7 +385,9 @@
         /// </summary>   
         private void InternalDispose()
         {
-            if (null != State && !State.IsAlive())
+            //Assume an unitialized connection state could still require a connection disposal
+            var connectionState = State;
+            if (null != connectionState && !connectionState.IsAlive())
             {
                 if (LOG.IsDebugEnabled)
                 {
@@ -403,7 +405,7 @@
             {
                 cnxn.Dispose();
             }
-            catch (IOException e)
+            catch (Exception e)
             {
                 if (LOG.IsDebugEnabled)
                 {

--- a/src/dotnet/ZooKeeperNet/ZooKeeper.cs
+++ b/src/dotnet/ZooKeeperNet/ZooKeeper.cs
@@ -385,7 +385,7 @@
         /// </summary>   
         private void InternalDispose()
         {
-            if (!State.IsAlive())
+            if (null != State && !State.IsAlive())
             {
                 if (LOG.IsDebugEnabled)
                 {


### PR DESCRIPTION
Responding to an issue raised in QA a few weeks ago that I do not believe was rectified in 3.3.4.6

Application: *****.exe
Framework Version: v4.0.30319
Description: The process was terminated due to an unhandled exception.
Exception Info: System.NullReferenceException
Stack:
   at ZooKeeperNet.ZooKeeper.InternalDispose()
   at ZooKeeperNet.ZooKeeper.Finalize()
