### PR TITLE
Use IZooKeeper instead of ZooKeeper directly to permit mocking.

### DIFF
--- a/src/dotnet/ZooKeeperNet.Recipes/ProtocolSupport.cs
+++ b/src/dotnet/ZooKeeperNet.Recipes/ProtocolSupport.cs
@@ -12,7 +12,7 @@
 
         private int closed;
 
-        public ProtocolSupport(ZooKeeper zookeeper)
+        public ProtocolSupport(IZooKeeper zookeeper)
         {
             RetryDelay = new TimeSpan(0, 0, 0, 0, 500);
             Acl = Ids.OPEN_ACL_UNSAFE;
@@ -20,7 +20,7 @@
             Zookeeper = zookeeper;
         }
 
-        public ZooKeeper Zookeeper { get; set; }
+        public IZooKeeper Zookeeper { get; set; }
 
         public TimeSpan RetryDelay { get; set; }
 

--- a/src/dotnet/ZooKeeperNet.Recipes/WriteLock.cs
+++ b/src/dotnet/ZooKeeperNet.Recipes/WriteLock.cs
@@ -35,10 +35,10 @@
 
         public event Action LockReleased;
 
-        public WriteLock(ZooKeeper zookeeper, string dir) : this(zookeeper, dir, null)
+        public WriteLock(IZooKeeper zookeeper, string dir) : this(zookeeper, dir, null)
         { }
 
-        public WriteLock(ZooKeeper zookeeper, string dir, List<ACL> acl) : base(zookeeper)
+        public WriteLock(IZooKeeper zookeeper, string dir, List<ACL> acl) : base(zookeeper)
         {
             this.dir = dir;
             if (acl != null) Acl = acl;
@@ -146,7 +146,7 @@
             return false;
         }
 
-        private void FindPrefixInChildren(String prefix, ZooKeeper zookeeper, String dir)
+        private void FindPrefixInChildren(String prefix, IZooKeeper zookeeper, String dir)
         {
             var names = Zookeeper.GetChildren(dir, false);
             foreach (string name in names)


### PR DESCRIPTION
Using the concrete ZooKeeper class instead of the IZooKeeper interface
was preventing use of mock frameworks like Rhino.Mocks to mock the
ZooKeeper service when testing code leveraging recipes.
