### PR TITLE
Support auto-creation of full path in ProtocolSupport.EnsureExists(...)

### DIFF
--- a/src/dotnet/ZooKeeperNet/PathUtils.cs
+++ b/src/dotnet/ZooKeeperNet/PathUtils.cs
@@ -32,6 +32,11 @@ namespace ZooKeeperNet
         public const char PathSeparatorChar = '/';
         private const char PathDotChar = '.';
 
+        /// <summary>
+        /// Path Separator char as an array for use in string.Split(delims, StringSplitOptions.*)
+        /// (and anywhere else this would be handy).
+        /// </summary>
+        public static readonly char[] PathSeparatorCharAsArray = new char[] {PathSeparatorChar};
 
         /** validate the provided znode path string
          * @param path znode path string


### PR DESCRIPTION
EnsureExists would only succeed if all parent nodes had already been
created before.  To follow the spirit of "Ensure*", this change works
through all the sub-nodes to make sure they exist, then creates the
final full path (writing the specified data only to the final node, not
the intermediate ones).
