### PR TITLE
Fix issue using multiple hosts connection string

### DIFF
--- a/src/dotnet/ZooKeeperNet.Tests/ClientTests.cs
+++ b/src/dotnet/ZooKeeperNet.Tests/ClientTests.cs
@@ -75,6 +75,35 @@
             }
         }
 
+       
+        [Test]
+        public void testClientWithMultipleHosts()
+        {
+            // With only a single ZooKeeper node running on port 2181, a connection should be established.
+            performCanConnect("127.0.0.1:2181,127.0.0.1:2182");
+            performCanConnect("127.0.0.1:2184,127.0.0.1:2183,127.0.0.1:2182,127.0.0.1:2181");
+            performCanConnect("127.0.0.1:2182,127.0.0.1:2181,127.0.0.1:2183");
+        }
+
+        private void performCanConnect(string hosts)
+        {
+            using (var zk = CreateClientWithAddress(hosts))
+            {
+                var timeout = TimeSpan.FromSeconds(30);
+                var connectionStartTime = DateTime.UtcNow;
+
+                while (!zk.State.Equals(ZooKeeper.States.CONNECTED))
+                {
+                    Thread.Sleep(1);
+
+                    if (DateTime.UtcNow.Subtract(connectionStartTime) > timeout)
+                        Assert.Fail("Could not connect to ZooKeeper within {0}s. hosts={1}", timeout.TotalSeconds, hosts);
+                }
+
+                Assert.Pass("Connected.");
+            }
+        }
+
         [Test]
         public void testClientWithoutWatcherObj()
         {

--- a/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
+++ b/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
@@ -78,7 +78,6 @@ namespace ZooKeeperNet
 
         public void Start()
         {
-            StartConnect();
             requestThread.Start();
         }
 

--- a/src/dotnet/ZooKeeperNet/ZooKeeper.cs
+++ b/src/dotnet/ZooKeeperNet/ZooKeeper.cs
@@ -225,7 +225,7 @@
         }
 
         private Guid id = Guid.NewGuid();
-        private States state;
+        private volatile States state = States.NOT_CONNECTED;
         private IClientConnection cnxn;
 
         /// <summary>


### PR DESCRIPTION
When using multiple hosts in a connection string, if the first host in the list is not available when the client object is created, a fatal exception is thrown, rather than try the next address in the list.
