### PR TITLE
Support dns round-robin in connection string

### DIFF
--- a/src/dotnet/ZooKeeperNet/ClientConnection.cs
+++ b/src/dotnet/ZooKeeperNet/ClientConnection.cs
@@ -158,11 +158,22 @@
                     }
                     host = h.Substring(0, pidx);
                 }
-                var ip = IPAddress.Parse(host);
-                serverAddrs.Add(new IPEndPoint(ip, port));
+
+                // Handle dns-round robin or hostnames instead of IP addresses
+                var hostIps = ResolveHostToIpAddresses(host);
+                foreach (var ip in hostIps)
+                {
+                    serverAddrs.Add(new IPEndPoint(ip, port));
+                }
             }
 
             serverAddrs.OrderBy(s => Guid.NewGuid()); //Random order the servers
+        }
+
+        private IEnumerable<IPAddress> ResolveHostToIpAddresses(string host)
+        {
+            var hostEntry = Dns.GetHostEntry(host);
+            return hostEntry.AddressList;
         }
 
         private void SetTimeouts(TimeSpan sessionTimeout)


### PR DESCRIPTION
Based on "http://wiki.apache.org/hadoop/ZooKeeper/FAQ#A8", I originally
tried leveraging dns round-robin, but it turns out that ZooKeeperDotNet
didn't support this.  Here is a change that will permit the client to be
initialized with a "connection string" that contains hostnames or ip
addresses, and will resolve a hostname to all associated IP addresses.
