### PR TITLE
Port of InterProcessLock / Mutex classes from apache curator.  Also, avoid null deref in ProcessWatcher, fix serverAddrs randomization, and avoid problems with IPV6 addesses.

### DIFF
--- a/src/dotnet/ZooKeeperNet.Recipes/Locks/InterProcessLock.cs
+++ b/src/dotnet/ZooKeeperNet.Recipes/Locks/InterProcessLock.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace ZooKeeperNet.Recipes.Locks
+{
+    /// <summary>
+    /// Roughly following the pattern from curator-recipes
+    /// See: http://curator.incubator.apache.org/curator-recipes/index.html
+    /// </summary>
+    public interface IInterProcessLock
+    {
+        /// <summary>
+        /// Acquire the mutex, blocking until it's available or the timeout passes.  Each call 
+        /// to Acquire() must be balanced by a call to Release.
+        /// 
+        /// NOTE: The same thread can call acquire re-entrantly.
+        /// </summary>
+        /// <param name="timeout">time to wait or null to wait indefinitely</param>
+        /// <returns>true if the mutex was acquired, false otherwise.</returns>
+        bool Acquire(TimeSpan? timeout = null);
+
+        /// <summary>
+        /// Perform a single release of the mutex.  If the thread had made multiple calls
+        /// to acquire, the mutex will continue to be held until all such calls are balanced
+        /// with corresponding Release() calls.
+        /// </summary>
+        void Release();
+
+        /// <summary>
+        /// Returns true if the mutex is acquired by a thread in this process.
+        /// </summary>
+        /// <returns></returns>
+        bool IsAcquiredInThisProcess();
+    }
+}

--- a/src/dotnet/ZooKeeperNet.Recipes/Locks/InterProcessMutex.cs
+++ b/src/dotnet/ZooKeeperNet.Recipes/Locks/InterProcessMutex.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+
+namespace ZooKeeperNet.Recipes.Locks
+{
+    /// <summary>
+    /// Roughly following the pattern from curator-recipes for a reentrant mutex that works across processes.
+    /// See: https://git-wip-us.apache.org/repos/asf?p=incubator-curator.git;a=blob;f=curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/InterProcessMutex.java;h=703cc8b03e4de560e73c3b78b5c29392a05eb62e;hb=master
+    /// </summary>
+    public class InterProcessMutex : IInterProcessLock
+    {
+        private readonly LockInternals _internals;
+        private readonly string _basePath;
+        private readonly ConcurrentDictionary<Thread, LockData> _threadData = new ConcurrentDictionary<Thread, LockData>();
+
+        private class LockData
+        {
+            public readonly Thread OwningThread;
+            public readonly string LockPath;
+
+            private int _lockCount = 1;
+            public int LockCount { get { return Interlocked.CompareExchange(ref _lockCount, 1, 1); } }
+            public int Inc() { return Interlocked.Increment(ref _lockCount); }
+            public int Dec() { return Interlocked.Decrement(ref _lockCount); }
+
+            public LockData(Thread owningThread, string lockPath)
+            {
+                OwningThread = owningThread;
+                LockPath = lockPath;
+            }
+        }
+
+        private const string LOCK_NAME = "lock-";
+
+        public InterProcessMutex(IZooKeeper client, string path)
+            : this(client, path, LOCK_NAME, 1, new StandardLockInternalsDriver())
+        { }
+
+        public InterProcessMutex(IZooKeeper client, string path, string lockName, int maxLeases,
+                                 ILockInternalsDriver driver)
+        {
+            _basePath = path;
+            _internals = new LockInternals(client, driver, path, lockName, maxLeases);
+        }
+
+        public bool Acquire(TimeSpan? timeout = null)
+        {
+            /*
+             * Note on concurrency: a given lockData instance
+             * can be only acted on by a single thread so locking isn't necessary
+             */
+            var hasLock = false;
+
+            var lockData = SafeGetLockData();
+            if (null != lockData)
+            {
+                // Re-entering
+                lockData.Inc();
+                hasLock = true;
+            }
+            else
+            {
+                var lockPath = _internals.AttemptLock(timeout, null);
+                if (null != lockPath)
+                {
+                    var newLockData = new LockData(Thread.CurrentThread, lockPath);
+                    SetLockData(newLockData);
+                    hasLock = true;
+                }
+            }
+
+            if (!hasLock && !timeout.HasValue)
+            {
+                throw new IOException("Lost connection while trying to acquire lock: " + _basePath);
+            }
+
+            return hasLock;
+        }
+
+        private LockData SafeGetLockData()
+        {
+            LockData theData;
+            _threadData.TryGetValue(Thread.CurrentThread, out theData);
+            return theData;
+        }
+
+        private void SetLockData(LockData theData)
+        {
+            _threadData[Thread.CurrentThread] = theData;
+        }
+
+        public void Release()
+        {
+            /*
+             * Note on concurrency: a given lockData instance
+             * can be only acted on by a single thread so locking isn't necessary
+             */
+
+            var lockData = SafeGetLockData();
+            if (null == lockData)
+            {
+                throw new InvalidOperationException("You do not own the lock: " + _basePath);
+            }
+
+            var newLockCount = lockData.Dec();
+            if (newLockCount > 0)
+            {
+                return;
+            }
+
+            if (newLockCount < 0)
+            {
+                throw new InvalidOperationException("Lock count has gone negative for lock: " + _basePath);
+            }
+
+            try
+            {
+                _internals.ReleaseLock(lockData.LockPath);
+                _internals.Dispose();
+            }
+            finally
+            {
+                LockData dummy;
+                _threadData.TryRemove(Thread.CurrentThread, out dummy);
+            }
+        }
+
+        public bool IsAcquiredInThisProcess()
+        {
+            return (_threadData.Count > 0);
+        }
+
+        public IEnumerable<string> GetParticipantNodes()
+        {
+            return _internals.GetParticipantNodes();
+        }
+
+        public bool IsOwnedByCurrentThread
+        {
+            get 
+            { 
+                var lockData = SafeGetLockData();
+                return (null != lockData) && (lockData.LockCount > 0);
+            }
+        }
+    }
+}

--- a/src/dotnet/ZooKeeperNet.Recipes/Locks/LockInternals.cs
+++ b/src/dotnet/ZooKeeperNet.Recipes/Locks/LockInternals.cs
@@ -1,0 +1,257 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Org.Apache.Zookeeper.Data;
+
+namespace ZooKeeperNet.Recipes.Locks
+{
+    /// <summary>
+    /// Common lock logic adapted from:
+    /// https://git-wip-us.apache.org/repos/asf?p=incubator-curator.git;a=blob;f=curator-recipes/src/main/java/org/apache/curator/framework/recipes/locks/LockInternals.java;h=06a1f6bd7b91c6e7133ab466b062ee25598f3554;hb=master
+    /// </summary>
+    public class LockInternals : IWatcher, IDisposable
+    {
+        private static readonly IRetryPolicy DefaultRetryPolicy = new RetryNTimes(5, TimeSpan.FromSeconds(5));
+
+        private readonly IZooKeeper _client;
+        private readonly string _path;
+        private readonly string _basePath;
+        private readonly ILockInternalsDriver _driver;
+        private readonly string _lockName;
+
+        // NOTE: Skipping "revokable" support for now
+
+        private IRetryPolicy _retryPolicy = DefaultRetryPolicy;
+
+        private readonly AutoResetEvent _watcherEvent = new AutoResetEvent(false);
+
+        private int _maxLeases;
+
+        public IRetryPolicy RetryPolicy
+        {
+            get { return _retryPolicy; }
+            set { _retryPolicy = value ?? DefaultRetryPolicy; }
+        }
+
+        public void Dispose()
+        {
+            Clean();
+            _watcherEvent.Dispose();
+        }
+
+        /// <summary>
+        /// Attempt to delete the lock node so that sequence numbers get reset.
+        /// </summary>
+        public void Clean()
+        {
+            try
+            {
+                // Don't blindly do delete or things get noisy in the INFO logs on the 
+                // server.
+                var stat = _client.Exists(_basePath, false);
+                if (null != stat && stat.NumChildren < 1)
+                {
+                    _client.Delete(_basePath, -1);
+                }
+            }
+            catch (KeeperException.BadVersionException)
+            {
+                // Intentially ignore this - another thread/process got the lock
+            }
+            catch (KeeperException.NotEmptyException)
+            {
+                // Intentially ignore this - other threads/processes are waiting
+            }
+        }
+
+        public LockInternals(IZooKeeper client, ILockInternalsDriver driver, string path, string lockName,
+                              int maxLeases)
+        {
+            _driver = driver;
+            _lockName = lockName;
+            _maxLeases = maxLeases;
+            PathUtils.ValidatePath(path);
+
+            _client = client;
+            _basePath = path;
+            _path = ZKPaths.MakePath(path, lockName);
+        }
+
+        private int MaxLeases
+        {
+            get { return Interlocked.CompareExchange(ref _maxLeases, 1, 1); }
+            set
+            {
+                Interlocked.Exchange(ref _maxLeases, value);
+                NotifyAll();
+            }
+        }
+
+        private void NotifyAll()
+        {
+            _watcherEvent.Set();
+        }
+
+        public void ReleaseLock(string lockPath)
+        {
+            DeleteOurPath(lockPath);
+        }
+
+        IZooKeeper Client { get { return _client; } }
+
+        public IEnumerable<string> GetParticipantNodes()
+        {
+            return GetParticipantNodes(Client, _basePath, _lockName, _driver);
+        }
+
+        public static IEnumerable<string> GetParticipantNodes(IZooKeeper client, string basePath, string lockName,
+                                                              ILockInternalsSorter sorter)
+        {
+            var names = GetSortedChildren(client, basePath, lockName, sorter);
+            var transformed = names.Select(x => ZKPaths.MakePath(basePath, x));
+            return transformed;
+        }
+
+        public static List<string> GetSortedChildren(IZooKeeper client, string basePath, string lockName,
+                                                              ILockInternalsSorter sorter)
+        {
+            var children = client.GetChildren(basePath, false);
+            return GetSortedChildren(lockName, sorter, children);
+        }
+
+        public static List<String> GetSortedChildren(string lockName, ILockInternalsSorter sorter, IEnumerable<string> children)
+        {
+            return new List<string>(children.OrderBy(x => sorter.FixForSorting(x, lockName)));
+        }
+
+        List<string> GetSortedChildren()
+        {
+            return GetSortedChildren(Client, _basePath, _lockName, Driver);
+        }
+
+        string LockName { get { return _lockName; } }
+
+        ILockInternalsDriver Driver { get { return _driver; } }
+
+        public string AttemptLock(TimeSpan? timeout, byte[] lockNodeBytes)
+        {
+            var startTime = DateTime.UtcNow;
+
+            var retryCount = 0;
+
+            string ourPath = null;
+            var hasTheLock = false;
+            var isDone = false;
+            while (!isDone)
+            {
+                isDone = true;
+
+                try
+                {
+                    ZKPaths.Mkdirs(Client, _path, false);
+                    ourPath = Client.Create(_path, lockNodeBytes, Driver.Acl ?? Ids.OPEN_ACL_UNSAFE, CreateMode.EphemeralSequential);
+                    hasTheLock = InternalLockLoop(startTime, timeout, ourPath);
+                }
+                catch (KeeperException.NoNodeException)
+                {
+                    // gets thrown by StandardLockInternalsDriver when it can't find the lock node
+                    // this can happen when the session expires, etc. So, if the retry allows, just try it all again
+                    if (RetryPolicy.AllowRetry(retryCount++, DateTime.UtcNow - startTime))
+                    {
+                        isDone = false;
+                    }
+                    else
+                    {
+                        throw;
+                    }
+                }
+            }
+
+            return hasTheLock ? ourPath : null;
+        }
+
+        private static TimeSpan RemainingTime(DateTime startTime, TimeSpan timeout)
+        {
+            return timeout - (DateTime.UtcNow - startTime);
+        }
+
+        private bool InternalLockLoop(DateTime startTime, TimeSpan? timeToWait, String ourPath)
+        {
+            var haveTheLock = false;
+            var doDelete = false;
+            try
+            {
+                while ((Client.State == ZooKeeper.States.CONNECTED) && !haveTheLock)
+                {
+                    var children = GetSortedChildren();
+                    var sequenceNodeName = ourPath.Substring(_basePath.Length + 1); // +1 to include the slash
+
+                    var predicateResults = Driver.GetsTheLock(Client, children, sequenceNodeName, MaxLeases);
+                    if (predicateResults.GetsTheLock)
+                    {
+                        haveTheLock = true;
+                    }
+                    else
+                    {
+                        var previousSequencePath = ZKPaths.MakePath(_basePath, predicateResults.PathToWatch);
+
+                        //                     synchronized(this)
+                        {
+                            var stat = Client.Exists(previousSequencePath, this);
+                            if (stat != null)
+                            {
+                                if (timeToWait.HasValue)
+                                {
+                                    var remainingTimeToWait = RemainingTime(startTime, timeToWait.Value);
+                                    if (remainingTimeToWait <= TimeSpan.Zero)
+                                    {
+                                        doDelete = true;    // timed out - delete our node
+                                        break;
+                                    }
+
+                                    _watcherEvent.WaitOne(remainingTimeToWait);
+                                }
+                                else
+                                {
+                                    _watcherEvent.WaitOne(-1);
+                                }
+                            }
+                        }
+                        // else it may have been deleted (i.e. lock released). Try to acquire again
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                doDelete = true;
+                throw;
+            }
+            finally
+            {
+                if (doDelete)
+                {
+                    DeleteOurPath(ourPath);
+                }
+            }
+            return haveTheLock;
+        }
+
+        private void DeleteOurPath(string ourPath)
+        {
+            try
+            {
+                Client.Delete(ourPath, -1);
+            }
+            catch (KeeperException.NoNodeException)
+            {
+                // ignore - already deleted (possibly expired session, etc.)
+            }
+        }
+
+        public void Process(WatchedEvent theEvent)
+        {
+            NotifyAll();
+        }
+    }
+}

--- a/src/dotnet/ZooKeeperNet.Recipes/Locks/LockInternalsDriver.cs
+++ b/src/dotnet/ZooKeeperNet.Recipes/Locks/LockInternalsDriver.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Org.Apache.Zookeeper.Data;
+using ZooKeeperNet;
+
+namespace ZooKeeperNet.Recipes.Locks
+{
+    public class PredicateResults
+    {
+        public readonly bool GetsTheLock;
+        public readonly string PathToWatch;
+
+        public PredicateResults(string pathToWatch, bool getsTheLock)
+        {
+            PathToWatch = pathToWatch;
+            GetsTheLock = getsTheLock;
+        }
+    }
+
+    public interface ILockInternalsSorter
+    {
+        string FixForSorting(string str, string lockName);
+    }
+
+    public interface ILockInternalsDriver : ILockInternalsSorter
+    {
+        IEnumerable<ACL> Acl { get; } 
+        PredicateResults GetsTheLock(IZooKeeper client, IEnumerable<string> children, string sequenceNodeName, int maxLeases);
+    }
+
+    public class StandardLockInternalsDriver : ILockInternalsDriver
+    {
+        private readonly IEnumerable<ACL> _acl;
+
+        public StandardLockInternalsDriver(IEnumerable<ACL> acl = null)
+        {
+            _acl = acl ?? Ids.OPEN_ACL_UNSAFE;
+        }
+
+        public IEnumerable<ACL> Acl { get { return _acl; } } 
+
+        public PredicateResults GetsTheLock(IZooKeeper client, IEnumerable<string> children, string sequenceNodeName, int maxLeases)
+        {
+            var scannableChildren = children as string[] ?? children.ToArray();
+            var ourIndex = Array.IndexOf(scannableChildren, sequenceNodeName);
+            ValidateOurIndex(sequenceNodeName, ourIndex);
+
+            var getsTheLock = ourIndex < maxLeases;
+            String pathToWatch = getsTheLock ? null : scannableChildren[ourIndex - maxLeases];
+
+            return new PredicateResults(pathToWatch, getsTheLock);
+        }
+
+        public string FixForSorting(string str, string lockName)
+        {
+            return StandardFixForSorting(str, lockName);
+        }
+
+        public static string StandardFixForSorting(string str, string lockName)
+        {
+            var index = str.LastIndexOf(lockName, StringComparison.InvariantCulture);
+            if (index >= 0)
+            {
+                index += lockName.Length;
+                return index <= str.Length ? str.Substring(index) : string.Empty;
+            }
+            return str;
+        }
+
+        static void ValidateOurIndex(String sequenceNodeName, int ourIndex)
+        {
+            if (ourIndex < 0)
+            {
+                throw new KeeperException.NoNodeException("Sequential path not found: " + sequenceNodeName);
+            }
+        }
+    }
+}

--- a/src/dotnet/ZooKeeperNet.Recipes/ZooKeeperNet.Recipes.csproj
+++ b/src/dotnet/ZooKeeperNet.Recipes/ZooKeeperNet.Recipes.csproj
@@ -71,6 +71,10 @@
       <Link>SolutionVersion.cs</Link>
     </Compile>
     <Compile Include="DistributedQueue.cs" />
+    <Compile Include="Locks\LockInternalsDriver.cs" />
+    <Compile Include="Locks\LockInternals.cs" />
+    <Compile Include="Locks\InterProcessLock.cs" />
+    <Compile Include="Locks\InterProcessMutex.cs" />
     <Compile Include="LeaderElection.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ProtocolSupport.cs" />

--- a/src/dotnet/ZooKeeperNet/ClientConnectionEventConsumer.cs
+++ b/src/dotnet/ZooKeeperNet/ClientConnectionEventConsumer.cs
@@ -56,7 +56,10 @@ using System.Collections.Generic;
             {
                 try
                 {
-                    watcher.Process(watchedEvent);
+                    if (null != watcher)
+                    {
+                        watcher.Process(watchedEvent);
+                    }
                 }
                 catch (Exception t)
                 {

--- a/src/dotnet/ZooKeeperNet/Properties/AssemblyInfo.cs
+++ b/src/dotnet/ZooKeeperNet/Properties/AssemblyInfo.cs
@@ -15,7 +15,7 @@
  *  limitations under the License.
  *
  */
-﻿using System.Reflection;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/src/dotnet/ZooKeeperNet/RetryPolicy.cs
+++ b/src/dotnet/ZooKeeperNet/RetryPolicy.cs
@@ -1,0 +1,80 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+﻿using System;
+using System.Linq;
+﻿using System.Collections.Generic;
+﻿using System.Text;
+﻿using System.Threading;
+
+namespace ZooKeeperNet
+{
+    public interface IRetryPolicy
+    {
+        bool AllowRetry(int retryCount, TimeSpan elapsedTime, Action<TimeSpan> retrySleeper = null);
+    }
+
+    public abstract class SleepingRetry : IRetryPolicy
+    {
+        private readonly int _n;
+
+        protected SleepingRetry(int n)
+        {
+            _n = n;
+        }
+
+        public int N { get { return _n; } }
+
+        public bool AllowRetry(int retryCount, TimeSpan elapsedTime, Action<TimeSpan> retrySleeper = null)
+        {
+            var allow = false;
+            var effectiveSleeper = retrySleeper ?? Thread.Sleep;
+
+            if (retryCount < _n)
+            {
+                try
+                {
+                    effectiveSleeper(GetSleepTime(retryCount, elapsedTime));
+                }
+                catch (ThreadInterruptedException)
+                {
+                    // Handle gracefully and don't allow retries
+                }
+                allow = true;
+            }
+            return allow;
+        }
+
+        protected abstract TimeSpan GetSleepTime(int retryCount, TimeSpan elapsedTime);
+    }
+
+    public class RetryNTimes : SleepingRetry
+    {
+        private readonly TimeSpan _sleepTime;
+
+        public RetryNTimes(int n, TimeSpan sleepTime)
+            : base(n)
+        {
+            _sleepTime = sleepTime;
+        }
+
+        protected override TimeSpan GetSleepTime(int retryCount, TimeSpan elapsedTime)
+        {
+            return _sleepTime;
+        }
+    }
+}

--- a/src/dotnet/ZooKeeperNet/ZKPaths.cs
+++ b/src/dotnet/ZooKeeperNet/ZKPaths.cs
@@ -1,0 +1,223 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+﻿using System;
+using System.Linq;
+﻿using System.Collections.Generic;
+﻿using System.Text;
+
+namespace ZooKeeperNet
+{
+    public class ZKPaths
+    {
+        /**
+         * Apply the namespace to the given path
+         *
+         * @param namespace namespace (can be null)
+         * @param path path
+         * @return adjusted path
+         */
+        public static String FixForNamespace(String theNamespace, String path)
+        {
+            if (theNamespace != null)
+            {
+                return MakePath(theNamespace, path);
+            }
+            return path;
+        }
+
+        /**
+         * Given a full path, return the node name. i.e. "/one/two/three" will return "three"
+         * 
+         * @param path the path
+         * @return the node
+         */
+        public static String GetNodeFromPath(String path)
+        {
+            PathUtils.ValidatePath(path);
+            var i = path.LastIndexOf(PathUtils.PathSeparatorChar);
+            if (i < 0)
+            {
+                return path;
+            }
+
+            if ((i + 1) >= path.Length)
+            {
+                return string.Empty;
+            }
+            return path.Substring(i + 1);
+        }
+
+        public class PathAndNode
+        {
+            public readonly string Path;
+            public readonly string Node;
+
+            public PathAndNode(string path, string node)
+            {
+                Path = path;
+                Node = node;
+            }
+        }
+
+        /**
+         * Given a full path, return the node name and its path. i.e. "/one/two/three" will return {"/one/two", "three"}
+         *
+         * @param path the path
+         * @return the node
+         */
+        public static PathAndNode GetPathAndNode(string path)
+        {
+            PathUtils.ValidatePath(path);
+            var i = path.LastIndexOf(PathUtils.PathSeparatorChar);
+            if (i < 0)
+            {
+                return new PathAndNode(path, string.Empty);
+            }
+            if ((i + 1) >= path.Length)
+            {
+                return new PathAndNode(PathUtils.PathSeparator, string.Empty);
+            }
+            var node = path.Substring(i + 1);
+            var parentPath = (i > 0) ? path.Substring(0, i) : PathUtils.PathSeparator;
+            return new PathAndNode(parentPath, node);
+        }
+
+        /**
+         * Make sure all the nodes in the path are created. NOTE: Unlike File.mkdirs(), Zookeeper doesn't distinguish
+         * between directories and files. So, every node in the path is created. The data for each node is an empty blob
+         *
+         * @param zookeeper the client
+         * @param path      path to ensure
+         * @throws InterruptedException thread interruption
+         * @throws org.apache.zookeeper.KeeperException
+         *                              Zookeeper errors
+         */
+        public static void Mkdirs(ZooKeeper zookeeper, String path)
+        {
+            Mkdirs(zookeeper, path, true);
+        }
+
+        /**
+         * Make sure all the nodes in the path are created. NOTE: Unlike File.mkdirs(), Zookeeper doesn't distinguish
+         * between directories and files. So, every node in the path is created. The data for each node is an empty blob
+         *
+         * @param zookeeper the client
+         * @param path      path to ensure
+         * @param makeLastNode if true, all nodes are created. If false, only the parent nodes are created
+         * @throws InterruptedException thread interruption
+         * @throws org.apache.zookeeper.KeeperException
+         *                              Zookeeper errors
+         */
+        public static void Mkdirs(IZooKeeper zookeeper, String path, bool makeLastNode)
+        {
+            PathUtils.ValidatePath(path);
+
+            var pos = 1; // skip first slash, root is guaranteed to exist
+            do
+            {
+                pos = path.IndexOf(PathUtils.PathSeparatorChar, pos + 1);
+
+                if (pos == -1)
+                {
+                    if (makeLastNode)
+                    {
+                        pos = path.Length;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+
+                var subPath = path.Substring(0, pos);
+                if (zookeeper.Exists(subPath, false) == null)
+                {
+                    try
+                    {
+                        zookeeper.Create(subPath, new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.Persistent);
+                    }
+                    catch (KeeperException.NodeExistsException e)
+                    {
+                        // ignore... someone else has created it since we checked
+                    }
+                }
+
+            }
+            while (pos < path.Length);
+        }
+
+        /**
+         * Return the children of the given path sorted by sequence number
+         *
+         * @param zookeeper the client
+         * @param path      the path
+         * @return sorted list of children
+         * @throws InterruptedException thread interruption
+         * @throws org.apache.zookeeper.KeeperException
+         *                              zookeeper errors
+         */
+        public static List<String> GetSortedChildren(IZooKeeper zookeeper, String path)
+        {
+            var children = zookeeper.GetChildren(path, false);
+            var sortedList = new List<string>(children.OrderBy(x => x));
+            return sortedList;
+        }
+
+        /**
+         * Given a parent path and a child node, create a combined full path
+         *
+         * @param parent the parent
+         * @param child  the child
+         * @return full path
+         */
+        public static String MakePath(String parent, String child)
+        {
+            var path = new StringBuilder();
+
+            if (!parent.StartsWith("/"))
+            {
+                path.Append("/");
+            }
+            path.Append(parent);
+            if (string.IsNullOrEmpty(child))
+            {
+                return path.ToString();
+            }
+
+            if (!parent.EndsWith(PathUtils.PathSeparator))
+            {
+                path.Append(PathUtils.PathSeparator);
+            }
+
+            if (child.StartsWith(PathUtils.PathSeparator))
+            {
+                path.Append(child.Substring(1));
+            }
+            else
+            {
+                path.Append(child);
+            }
+
+            return path.ToString();
+        }
+
+        private ZKPaths()
+        {
+        }
+    }
+}

--- a/src/dotnet/ZooKeeperNet/ZooKeeperNet.csproj
+++ b/src/dotnet/ZooKeeperNet/ZooKeeperNet.csproj
@@ -76,6 +76,8 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="ClientWatchManager.cs" />
+    <Compile Include="RetryPolicy.cs" />
+    <Compile Include="ZKPaths.cs" />
     <Compile Include="CreateMode.cs" />
     <Compile Include="DataTree.cs" />
     <Compile Include="ClientConnectionEventConsumer.cs" />


### PR DESCRIPTION
The WriteLock class implements locking with immediate success or immediate failure, but does not help if you want a client to "block" for a time until the lock becomes available.  Apache curator has very nice implementations of many recipes, including Mutexes.  I needed such a Mutex implementation, so I've done a rough port of the one from apache curator.  The curator implementation assumes a client wrapper from the curator library that I did not port, so instead, I've made the implementation depend on IZooKeeper... this is the primary difference.

Also in this pull request, some minor bug fixes including:
- avoiding a null deref in  ProcessWatcher
- fixing serverAddrs randomization
- avoid some issues with IPV6 in the name resolution step
