### PR TITLE
RF-402: added connection timeout, retry to different zkserver and expone...

### DIFF
--- a/src/dotnet/SolutionVersion.cs
+++ b/src/dotnet/SolutionVersion.cs
@@ -5,10 +5,10 @@ using System.Security;
 [assembly: AssemblyDescription("ZooKeeper Client for .NET http://zookeeper.apache.org")]
 [assembly: AssemblyProduct("ZooKeeperNet")]
 [assembly: AssemblyCopyright("Copyright 2007-2012 ewhauser, omwok. - All rights reserved.")]
-[assembly: AssemblyVersion("3.3.4.7")]
-[assembly: AssemblyFileVersion("3.3.4.7")]
+[assembly: AssemblyVersion("3.3.4.8")]
+[assembly: AssemblyFileVersion("3.3.4.8")]
 
-[assembly: AssemblyInformationalVersion("3.3.4.7")]
+[assembly: AssemblyInformationalVersion("3.3.4.8")]
 [assembly: ComVisibleAttribute(false)]
 [assembly: CLSCompliantAttribute(false)]
 

--- a/src/dotnet/ZooKeeperNet.Tests/ZooKeeperEndpointTests.cs
+++ b/src/dotnet/ZooKeeperNet.Tests/ZooKeeperEndpointTests.cs
@@ -1,0 +1,157 @@
+﻿/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace ZooKeeperNet.Tests
+{
+    using System;
+    using System.Net;
+    using System.Threading;
+    using System.Collections.Generic;
+    using log4net;
+    using NUnit.Framework;
+    using Org.Apache.Zookeeper.Data;
+
+    [TestFixture]
+    public class ZooKeeperEndPointTests : AbstractZooKeeperTests
+    {
+        private const int port = 2181;
+        private const int retryCeiling = 10;
+        private readonly TimeSpan defaultbackoffInterval = new TimeSpan(0, 2, 0);
+        private readonly List<string> ips = new List<string>{"1.1.1.1", "1.1.1.2", "1.1.1.3", "1.1.1.4", "1.1.1.5"};
+        private readonly ILog LOG = LogManager.GetLogger(typeof(ZooKeeperEndPointTests));
+        private ZooKeeperEndpoints zkEndpoints = null;
+
+        [SetUp]
+        public void Init()
+        {
+            //create endpoints
+            zkEndpoints = new ZooKeeperEndpoints(ips.ConvertAll(x => IPAddress.Parse(x))
+                .ConvertAll(y => new IPEndPoint(y, port)));
+        }
+
+        [Test]
+        public void testBackoff() 
+        {
+            List<int> expectedBackoff = new List<int>{1,1,3,7,15,31,63,127,255,511};
+            DateTime nextAvailable = DateTime.Now;
+            DateTime lastAvailable = DateTime.Now;
+            TimeSpan backoff;
+            int totalMinutes;
+
+            for (int i = 1; i <= retryCeiling; i++)
+            {
+                lastAvailable = nextAvailable;
+                nextAvailable = ZooKeeperEndpoint.GetNextAvailability(nextAvailable, defaultbackoffInterval, i);
+                backoff = nextAvailable - lastAvailable;
+                totalMinutes = (int)backoff.TotalMinutes;
+                Assert.AreEqual(expectedBackoff[i - 1], totalMinutes);
+            }
+        }
+
+
+        [Test]
+        public void testConnectionRetry()
+        {
+            //set all to failure
+            for (int i = 0; i <= ips.Count; i++)
+            {
+                zkEndpoints.GetNextAvailableEndpoint();
+                zkEndpoints.CurrentEndPoint.SetAsFailure();
+            }
+
+            zkEndpoints.GetNextAvailableEndpoint();
+            //verify that we've cycled back to the first connection
+            Assert.AreEqual(ips[4], zkEndpoints.CurrentEndPoint.ServerAddress.Address.ToString());
+            
+            //verify verify this connection is available
+            Assert.AreEqual(DateTime.MinValue, zkEndpoints.CurrentEndPoint.NextAvailability);
+            
+            //call succeeded
+            zkEndpoints.CurrentEndPoint.SetAsSuccess();
+
+            //verify that this is the only connection made available
+            for (int i = 0; i <= (ips.Count * 2); i++)
+            {
+                zkEndpoints.GetNextAvailableEndpoint();
+                Assert.AreEqual(ips[4], zkEndpoints.CurrentEndPoint.ServerAddress.Address.ToString());
+            }
+
+            //set all back to success
+            for (int i = 0; i <= ips.Count; i++)
+            {
+                zkEndpoints.GetNextAvailableEndpoint();
+                zkEndpoints.CurrentEndPoint.SetAsSuccess();
+                Assert.AreEqual(DateTime.MinValue, zkEndpoints.CurrentEndPoint.NextAvailability);
+            }
+        }
+        
+        [Test, Explicit]
+        public void testBackoffExpiration()
+        {
+            //set all to failure
+            for (int i = 0; i <= ips.Count; i++)
+            {
+                zkEndpoints.GetNextAvailableEndpoint();
+                zkEndpoints.CurrentEndPoint.SetAsFailure();
+            }
+
+            DateTime backoffTime = zkEndpoints.CurrentEndPoint.NextAvailability;
+
+            do
+            {
+                zkEndpoints.GetNextAvailableEndpoint();
+                if (DateTime.Now > backoffTime)
+                {
+                    //when the backoff ends we should cycle back to the first connection
+                    Assert.AreEqual(ips[0], zkEndpoints.CurrentEndPoint.ServerAddress.Address.ToString());
+                    break;
+                }
+                //This should be the only connection attempted during the backoff
+                Assert.AreEqual(ips[4], zkEndpoints.CurrentEndPoint.ServerAddress.Address.ToString());
+                Thread.Sleep(500);
+            } while (1 == 1);
+        }
+
+        [Test, Explicit]
+        public void testOutageRecovery()
+        {
+            //set all to failure
+            for (int i = 0; i <= ips.Count; i++)
+            {
+                zkEndpoints.GetNextAvailableEndpoint();
+                zkEndpoints.CurrentEndPoint.SetAsFailure();
+            }
+
+            DateTime backoffTime = zkEndpoints.CurrentEndPoint.NextAvailability.AddMinutes(1d);
+
+            do
+            {
+                zkEndpoints.GetNextAvailableEndpoint();
+                zkEndpoints.CurrentEndPoint.SetAsSuccess();
+                if (DateTime.Now > backoffTime)
+                {
+                    foreach (ZooKeeperEndpoint z in zkEndpoints)
+                    {
+                        Assert.AreEqual(z.NextAvailability, DateTime.MinValue);
+                    }
+                    break;
+                }
+                Thread.Sleep(500);
+            } while (1 == 1);
+        }
+    }
+}

--- a/src/dotnet/ZooKeeperNet.Tests/ZooKeeperNet.Tests.csproj
+++ b/src/dotnet/ZooKeeperNet.Tests/ZooKeeperNet.Tests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="NullDataTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StatTests.cs" />
+    <Compile Include="ZooKeeperEndpointTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/src/dotnet/ZooKeeperNet/ZooKeeperEndpoint.cs
+++ b/src/dotnet/ZooKeeperNet/ZooKeeperEndpoint.cs
@@ -1,0 +1,77 @@
+﻿/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+namespace ZooKeeperNet
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Net;
+
+    public class ZooKeeperEndpoint
+    {
+        private const int retryCeiling = 10;
+        private readonly IPEndPoint serverAddress;
+        private DateTime nextAvailability = DateTime.MinValue;
+        private int retryAttempts = 0;
+        private TimeSpan backoffInterval;
+
+        public ZooKeeperEndpoint(IPEndPoint serverAddress, TimeSpan backoffInterval)
+        {
+            this.serverAddress = serverAddress;
+            this.backoffInterval = backoffInterval;
+        }
+
+        public IPEndPoint ServerAddress
+        {
+            get { return this.serverAddress; }
+        }
+
+        public DateTime NextAvailability
+        {
+            get { return this.nextAvailability; }
+        }
+
+        public int RetryAttempts
+        {
+            get { return this.retryAttempts; }
+        }
+
+        public void SetAsSuccess()
+        {
+            this.retryAttempts = 0;
+            this.nextAvailability = DateTime.MinValue;
+        }
+
+        public void SetAsFailure()
+        {
+            this.retryAttempts++;
+            this.nextAvailability = this.nextAvailability == DateTime.MinValue ? DateTime.Now : this.nextAvailability;
+            this.nextAvailability = GetNextAvailability(this.nextAvailability, this.backoffInterval, this.retryAttempts);
+        }
+
+        public static DateTime GetNextAvailability(DateTime currentAvailability, TimeSpan backoffInterval, int retryAttempts)
+        {
+            double backoffIntervalMinutes = backoffInterval.Minutes >= 1 ? backoffInterval.Minutes : 1;
+            int backoffMinutes = (int)((1d / backoffIntervalMinutes) * (Math.Pow(backoffIntervalMinutes, Math.Min(retryAttempts, retryCeiling)) - 1d));
+            backoffMinutes = backoffMinutes >= 1 ? backoffMinutes : 1;
+            return currentAvailability.AddMinutes(backoffMinutes);
+        }
+    }
+}

--- a/src/dotnet/ZooKeeperNet/ZooKeeperEndpoints.cs
+++ b/src/dotnet/ZooKeeperNet/ZooKeeperEndpoints.cs
@@ -1,0 +1,141 @@
+﻿/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+namespace ZooKeeperNet
+{
+    using System.Text;
+    using System.Net;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    public class ZooKeeperEndpoints:IEnumerable<ZooKeeperEndpoint>
+    {
+        private static readonly TimeSpan defaultBackoffInterval = new TimeSpan(0,2,0); 
+        private List<ZooKeeperEndpoint> zkEndpoints = new List<ZooKeeperEndpoint>();
+        private ZooKeeperEndpoint endpoint = null;
+        private int endpointID = -1;
+        private bool isNextEndPointAvailable = true;
+        private TimeSpan backoffInterval;
+
+       
+        public ZooKeeperEndpoints(List<IPEndPoint> endpoints)
+            : this(endpoints, defaultBackoffInterval)
+        {
+        }
+
+        public ZooKeeperEndpoints(List<IPEndPoint> endpoints, TimeSpan backoffInterval)
+        {
+            this.backoffInterval = backoffInterval;
+            AddRange(endpoints);
+        }
+
+        public IEnumerator<ZooKeeperEndpoint> GetEnumerator()
+        {
+            return this.zkEndpoints.GetEnumerator();
+        }
+
+        public void Add(IPEndPoint endPoint)
+        {
+            this.Add(new ZooKeeperEndpoint(endPoint, backoffInterval));
+        }
+
+        public void Add(ZooKeeperEndpoint endPoint)
+        {
+            zkEndpoints.Add(endPoint);        
+        }
+
+        public void AddRange(List<ZooKeeperEndpoint> endPoints)
+        {
+            this.zkEndpoints.AddRange((IEnumerable<ZooKeeperEndpoint>)endPoints);
+        }
+
+        public void AddRange(List<IPEndPoint> endPoints)
+        {
+            AddRange(endPoints.ConvertAll(e => new ZooKeeperEndpoint(e, backoffInterval)));
+        }
+
+        public ZooKeeperEndpoint CurrentEndPoint
+        { 
+            get { return this.endpoint;}
+        }
+
+        public int EndPointID
+        {
+            get { return this.endpointID; }    
+        }
+
+        public bool IsNextEndPointAvailable
+        {
+            get { return this.isNextEndPointAvailable; }
+        }
+
+        public void GetNextAvailableEndpoint()
+        {
+            isNextEndPointAvailable = true;
+            if(this.zkEndpoints.Count > 0)
+            {
+                int startingPosition = endpointID;
+                do
+                {
+                    endpointID++;
+                    if (endpointID == zkEndpoints.Count)
+                    {
+                        endpointID = 0;
+                    }
+
+                    if (endpointID == startingPosition)
+                    { 
+                        //All connections are disabled.
+                        //Try one at a time until success
+                        ResetConnections(endpointID);
+                    }
+                }
+                while (this.zkEndpoints[endpointID].NextAvailability > DateTime.Now);
+            }
+
+            this.endpoint = zkEndpoints[endpointID];
+        }
+
+        private void ResetConnections(int currentPostition)
+        {
+            for (int i = 0; i < zkEndpoints.Count; i++)
+            {
+                if (zkEndpoints[i].RetryAttempts > 1)
+                {
+                    //clear connection
+                    zkEndpoints[i].SetAsSuccess();
+                    //set back to lowest backoff
+                    zkEndpoints[i].SetAsFailure();
+                }
+            }
+
+            //Enable current connection
+            zkEndpoints[endpointID].SetAsSuccess();
+            isNextEndPointAvailable = false;
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+
+    }
+}
+    

--- a/src/dotnet/ZooKeeperNet/ZooKeeperNet.csproj
+++ b/src/dotnet/ZooKeeperNet/ZooKeeperNet.csproj
@@ -169,6 +169,8 @@
     <Compile Include="IWatcher.cs" />
     <Compile Include="ZKWatchManager.cs" />
     <Compile Include="ZooKeeper.cs" />
+    <Compile Include="ZooKeeperEndpoint.cs" />
+    <Compile Include="ZooKeeperEndpoints.cs" />
     <Compile Include="ZooKeeperEx.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
These changes were driven by an outage caused by the inability to quickly ignore a zookeeper server that is down for a prolonged period of time.
