### PR TITLE
Fix ResolveHostToIpAddresses for Mono

### DIFF
--- a/src/dotnet/ZooKeeperNet/ClientConnection.cs
+++ b/src/dotnet/ZooKeeperNet/ClientConnection.cs
@@ -211,8 +211,7 @@ namespace ZooKeeperNet
         private IEnumerable<IPAddress> ResolveHostToIpAddresses(string host)
         {
             var hostEntry = Dns.GetHostEntry(host);
-            return hostEntry.AddressList.Where(x => 
-                !x.IsIPv6LinkLocal && !x.IsIPv6SiteLocal && !x.IsIPv6Multicast && !x.IsIPv6Teredo);
+            return hostEntry.AddressList.Where(x => x.AddressFamily == AddressFamily.InterNetwork);
         }
 
         private void SetTimeouts(TimeSpan sessionTimeout)


### PR DESCRIPTION
Mono does not support System.Net.IPAddress.IsIPv6Teredo. This maintains that host addresses are only IPv4, but does so using IPAddress.AddressFamily.
