### PR TITLE
Fix DateTime.Now daylight savings bugs

### DIFF
--- a/src/dotnet/ZooKeeperNet.Tests/AbstractZooKeeperTests.cs
+++ b/src/dotnet/ZooKeeperNet.Tests/AbstractZooKeeperTests.cs
@@ -104,7 +104,7 @@ namespace ZooKeeperNet.Tests
             [MethodImpl(MethodImplOptions.Synchronized)]
             void waitForConnected(TimeSpan timeout)
             {
-                DateTime expire = DateTime.Now + timeout;
+                DateTime expire = DateTime.UtcNow + timeout;
                 TimeSpan left = timeout;
                 while (!connected && left.TotalMilliseconds > 0)
                 {
@@ -112,7 +112,7 @@ namespace ZooKeeperNet.Tests
                     {
                         Monitor.TryEnter(sync, left);
                     }
-                    left = expire - DateTime.Now;
+                    left = expire - DateTime.UtcNow;
                 }
                 if (!connected)
                 {
@@ -123,7 +123,7 @@ namespace ZooKeeperNet.Tests
 
             void waitForDisconnected(TimeSpan timeout)
             {
-                DateTime expire = DateTime.Now + timeout;
+                DateTime expire = DateTime.UtcNow + timeout;
                 TimeSpan left = timeout;
                 while (connected && left.TotalMilliseconds > 0)
                 {
@@ -131,7 +131,7 @@ namespace ZooKeeperNet.Tests
                     {
                         Monitor.TryEnter(sync, left);
                     }
-                    left = expire - DateTime.Now;
+                    left = expire - DateTime.UtcNow;
                 }
                 if (connected)
                 {

--- a/src/dotnet/ZooKeeperNet.Tests/CountDownLatch.cs
+++ b/src/dotnet/ZooKeeperNet.Tests/CountDownLatch.cs
@@ -19,7 +19,7 @@ namespace ZooKeeperNet.Tests
 
         public bool Await(TimeSpan wait)
         {
-            start = DateTime.Now;
+            start = DateTime.UtcNow;
             remaining = wait;
             while (count < occurences)
             {
@@ -31,7 +31,7 @@ namespace ZooKeeperNet.Tests
 
         public void CountDown()
         {
-            remaining = DateTime.Now - start;
+            remaining = DateTime.UtcNow - start;
             Interlocked.Increment(ref count);
             reset.Set();
         }

--- a/src/dotnet/ZooKeeperNet.Tests/ZooKeeperEndpointTests.cs
+++ b/src/dotnet/ZooKeeperNet.Tests/ZooKeeperEndpointTests.cs
@@ -47,8 +47,8 @@ namespace ZooKeeperNet.Tests
         public void testBackoff() 
         {
             List<int> expectedBackoff = new List<int>{1,1,3,7,15,31,63,127,255,511};
-            DateTime nextAvailable = DateTime.Now;
-            DateTime lastAvailable = DateTime.Now;
+            DateTime nextAvailable = DateTime.UtcNow;
+            DateTime lastAvailable = DateTime.UtcNow;
             TimeSpan backoff;
             int totalMinutes;
 
@@ -114,7 +114,7 @@ namespace ZooKeeperNet.Tests
             do
             {
                 zkEndpoints.GetNextAvailableEndpoint();
-                if (DateTime.Now > backoffTime)
+                if (DateTime.UtcNow > backoffTime)
                 {
                     //when the backoff ends we should cycle back to the first connection
                     Assert.AreEqual(ips[0], zkEndpoints.CurrentEndPoint.ServerAddress.Address.ToString());
@@ -142,7 +142,7 @@ namespace ZooKeeperNet.Tests
             {
                 zkEndpoints.GetNextAvailableEndpoint();
                 zkEndpoints.CurrentEndPoint.SetAsSuccess();
-                if (DateTime.Now > backoffTime)
+                if (DateTime.UtcNow > backoffTime)
                 {
                     foreach (ZooKeeperEndpoint z in zkEndpoints)
                     {

--- a/src/dotnet/ZooKeeperNet/ClientConnection.cs
+++ b/src/dotnet/ZooKeeperNet/ClientConnection.cs
@@ -300,13 +300,13 @@ namespace ZooKeeperNet
                 {
                     SubmitRequest(new RequestHeader { Type = (int)OpCode.CloseSession }, null, null, null);
                     SpinWait spin = new SpinWait();
-                    DateTime start = DateTime.Now;
+                    DateTime timeoutAt = DateTime.UtcNow.Add(SessionTimeout);
                     while (!producer.IsConnectionClosedByServer)
                     {
                         spin.SpinOnce();
                         if (spin.Count > maxSpin)
                         {
-                            if (DateTime.Now.Subtract(start) > SessionTimeout)
+                            if (timeoutAt <= DateTime.UtcNow)
                             {
                                 throw new TimeoutException(
                                     string.Format("Timed out in Dispose() while closing session: 0x{0:X}", SessionId));

--- a/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
+++ b/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
@@ -123,7 +123,7 @@ namespace ZooKeeperNet
 
         private void SendRequests()
         {
-            DateTime now = DateTime.Now;
+            DateTime now = DateTime.UtcNow;
             DateTime lastSend = now;
             Packet packet = null;
             SpinWait spin = new SpinWait();
@@ -131,7 +131,7 @@ namespace ZooKeeperNet
             {
                 try
                 {
-                    now = DateTime.Now;
+                    now = DateTime.UtcNow;
                     if (client == null || !client.Connected || zooKeeper.State == ZooKeeper.States.NOT_CONNECTED)
                     {
                         // don't re-establish connection if we are closing
@@ -162,7 +162,7 @@ namespace ZooKeeperNet
                             // We have something to send so it's the same
                             // as if we do the send now.                        
                             DoSend(packet);
-                            lastSend = DateTime.Now;
+                            lastSend = DateTime.UtcNow;
                             packet = null;
                         }
                         else
@@ -462,7 +462,7 @@ namespace ZooKeeperNet
 
         private void SendPing()
         {
-            lastPingSentNs = DateTime.Now.Nanos();
+            lastPingSentNs = DateTime.UtcNow.Nanos();
             RequestHeader h = new RequestHeader(-2, (int)OpCode.Ping);
             conn.QueuePacket(h, null, null, null, null, null, null, null, null);
         }
@@ -534,7 +534,7 @@ namespace ZooKeeperNet
                 {
                     // -2 is the xid for pings
                     if (LOG.IsDebugEnabled)
-                        LOG.DebugFormat("Got ping response for sessionid: 0x{0:X} after {1}ms", conn.SessionId, (DateTime.Now.Nanos() - lastPingSentNs) / 1000000);
+                        LOG.DebugFormat("Got ping response for sessionid: 0x{0:X} after {1}ms", conn.SessionId, (DateTime.UtcNow.Nanos() - lastPingSentNs) / 1000000);
                     return;
                 }
                 if (replyHdr.Xid == -4)

--- a/src/dotnet/ZooKeeperNet/ZooKeeperEndpoint.cs
+++ b/src/dotnet/ZooKeeperNet/ZooKeeperEndpoint.cs
@@ -62,7 +62,7 @@ namespace ZooKeeperNet
         public void SetAsFailure()
         {
             this.retryAttempts++;
-            this.nextAvailability = this.nextAvailability == DateTime.MinValue ? DateTime.Now : this.nextAvailability;
+            this.nextAvailability = this.nextAvailability == DateTime.MinValue ? DateTime.UtcNow : this.nextAvailability;
             this.nextAvailability = GetNextAvailability(this.nextAvailability, this.backoffInterval, this.retryAttempts);
         }
 

--- a/src/dotnet/ZooKeeperNet/ZooKeeperEndpoints.cs
+++ b/src/dotnet/ZooKeeperNet/ZooKeeperEndpoints.cs
@@ -106,7 +106,7 @@ namespace ZooKeeperNet
                         ResetConnections(endpointID);
                     }
                 }
-                while (this.zkEndpoints[endpointID].NextAvailability > DateTime.Now);
+                while (this.zkEndpoints[endpointID].NextAvailability > DateTime.UtcNow);
             }
 
             this.endpoint = zkEndpoints[endpointID];


### PR DESCRIPTION
Using DateTime.Now will cause issues when daylight savings kicks in.  DateTime.Now can jump forward or backwards one hour which will cause problems with timeouts or pings.
