### PR TITLE
Do not use DNS lookup when connection string uses IP address explicitly.

### DIFF
--- a/src/dotnet/ZooKeeperNet/ClientConnectionEventConsumer.cs
+++ b/src/dotnet/ZooKeeperNet/ClientConnectionEventConsumer.cs
@@ -83,7 +83,7 @@ using System.Collections.Generic;
                         else
                         {
                             spin.SpinOnce();
-                            if (spin.Count > ClientConnection.maxSpin)
+                            if (spin.Count > ClientConnection.MaximumSpin)
                                 spin.Reset();
                         }
                         

--- a/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
+++ b/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
@@ -437,7 +437,7 @@ namespace ZooKeeperNet
 
             lock (outgoingQueue)
             {
-                if (!ClientConnection.disableAutoWatchReset && (!zooKeeper.DataWatches.IsEmpty() || !zooKeeper.ExistWatches.IsEmpty() || !zooKeeper.ChildWatches.IsEmpty()))
+                if (!ClientConnection.DisableAutoWatchReset && (!zooKeeper.DataWatches.IsEmpty() || !zooKeeper.ExistWatches.IsEmpty() || !zooKeeper.ChildWatches.IsEmpty()))
                 {
                     var sw = new SetWatches(lastZxid, zooKeeper.DataWatches, zooKeeper.ExistWatches, zooKeeper.ChildWatches);
                     var h = new RequestHeader();
@@ -491,7 +491,7 @@ namespace ZooKeeperNet
             using (EndianBinaryReader reader = new EndianBinaryReader(EndianBitConverter.Big, new MemoryStream(content), Encoding.UTF8))
             {
                 int len = reader.ReadInt32();
-                if (len < 0 || len >= ClientConnection.packetLen)
+                if (len < 0 || len >= ClientConnection.MaximumPacketLength)
                     throw new IOException(new StringBuilder("Packet len ").Append(len).Append("is out of range!").ToString());
                 return len;
             }

--- a/src/dotnet/ZooKeeperNet/Jute/BinaryInputArchive.cs
+++ b/src/dotnet/ZooKeeperNet/Jute/BinaryInputArchive.cs
@@ -117,7 +117,7 @@ namespace Org.Apache.Jute
         {
             int len = ReadInt(tag);
             if (len == -1) return null;
-            if (len < 0 || len > ClientConnection.packetLen)
+            if (len < 0 || len > ClientConnection.MaximumPacketLength)
             {
                 throw new IOException(new StringBuilder("Unreasonable length = ").Append(len).ToString());
             }

--- a/src/dotnet/ZooKeeperNet/ZKWatchManager.cs
+++ b/src/dotnet/ZooKeeperNet/ZKWatchManager.cs
@@ -68,7 +68,7 @@
                     }
 
                     // clear the watches if auto watch reset is not enabled
-                    if (ClientConnection.disableAutoWatchReset &&
+                    if (ClientConnection.DisableAutoWatchReset &&
                         state != KeeperState.SyncConnected)
                     {
                         dataWatches.Clear();


### PR DESCRIPTION
If the user configures to use IP address instead of a DNS name, do not resolve to other IP addresses on the computer.  This resolves a couple of issues:
1. remote IP addresses may not be resolvable by DNS. Dns.GetHostEntry(string) will throw an exception in this case.
2. ZooKeeper may not be listening on all IP addresses of a server. This can be a problem with localhost (ie, development environment). The machine may have multiple network interfaces (LAN, WiFi, VMware, VirtualBox, etc). The user can force the use of the specified address by using IP addresses directly in the configuration.

This change also has extracted out the logic to select the returned addresses by address family. The original code only selects the IPv4 addresses.  In the future, IPv6 should be supported.
