### PR TITLE
make use of .net's BlockingCollection

### DIFF
--- a/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
+++ b/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
@@ -126,7 +126,7 @@ namespace ZooKeeperNet
             DateTime now = DateTime.UtcNow;
             DateTime lastSend = now;
             Packet packet = null;
-            SpinWait spin = new SpinWait();
+
             while (zooKeeper.State.IsAlive())
             {
                 try


### PR DESCRIPTION
This converts from a SpinWait to a Semaphore if there are no events after the SpinWait times out.  This prevents unneccesary spinning of the CPU when there are no events in the queue for long period of time.
