### PR TITLE
Update ClientConnectionRequestProducer.cs

### DIFF
--- a/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
+++ b/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
@@ -132,7 +132,7 @@ namespace ZooKeeperNet
                 try
                 {
                     now = DateTime.UtcNow;
-                    if (client == null || !client.Connected || zooKeeper.State == ZooKeeper.States.NOT_CONNECTED)
+                    if ((client == null || client.Client == null) || (!client.Connected || zooKeeper.State == ZooKeeper.States.NOT_CONNECTED))
                     {
                         // don't re-establish connection if we are closing
                         if(conn.IsClosed || closing)


### PR DESCRIPTION
Fixed an connection BUG,If Socket connection is lost, it will cause the TcpClient Client Properties to null, causing a NullReferenceException, leading to rewiring an endless loop, CPU 100%
