### PR TITLE
Fix re-connection bug

### DIFF
--- a/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
+++ b/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
@@ -379,7 +379,14 @@ namespace ZooKeeperNet
                 if (client == null)
                     return;
                 NetworkStream stream = client.GetStream();
-                len = stream.EndRead(ar);
+
+                try
+                {
+                    len = stream.EndRead(ar);
+                }
+                catch
+                {
+                }
                 if (len == 0) //server closed the connection...
                 {
                     LOG.Debug("TcpClient connection lost.");


### PR DESCRIPTION
In some rare occasion when the connection to ZooKeeper is unstable, the `ReceiveAsynch` method in `ClientConnectionRequestProducer` throws exception at following line

```
len = stream.EndRead(ar);
```

Here is what I got from log.

```
ERROR2015-04-19 08:20:38 – System.IO.IOException: Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond. ---> System.Net.Sockets.SocketException: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond
   at System.Net.Sockets.NetworkStream.EndRead(IAsyncResult asyncResult)
   --- End of inner exception stack trace ---
   at System.Net.Sockets.NetworkStream.EndRead(IAsyncResult asyncResult)
   at ZooKeeperNet.ClientConnectionRequestProducer.ReceiveAsynch(IAsyncResult ar)
```

However, ZooKeeperNet it catches this exception and don't have any further process, this leads to problem that -- it can't reconnect to zookeeper.

This fix is to ignore this exception so it is treated as disconnected.
