### PR TITLE
Bug fix where 2 candidates can become leaders

### DIFF
--- a/src/dotnet/ZooKeeperNet.Recipes.Tests/LeaderElectionTests.cs
+++ b/src/dotnet/ZooKeeperNet.Recipes.Tests/LeaderElectionTests.cs
@@ -37,7 +37,7 @@ namespace ZooKeeperNetRecipes.Tests {
 		}
 
 		private class TestLeaderWatcher : ILeaderWatcher {
-			public static byte Leader;
+			public byte Leader;
 			private readonly byte b;
 
 			public TestLeaderWatcher(byte b) {
@@ -53,7 +53,6 @@ namespace ZooKeeperNetRecipes.Tests {
 		[Test]
 		public void testElection() {
 			String dir = "/test";
-			String testString = "Hello World";
 			int num_clients = 10;
 			clients = new ZooKeeper[num_clients];
 			LeaderElection[] elections = new LeaderElection[num_clients];
@@ -72,31 +71,35 @@ namespace ZooKeeperNetRecipes.Tests {
 			Assert.Pass();
 		}
 
-        [Test]
-	    public void testNode4DoesNotBecomeLeaderWhenNonLeader3Closes()
-	    {
-            string dir = "/test";
-            int num_clients = 4;
-            clients = new ZooKeeper[num_clients];
-            LeaderElection[] elections = new LeaderElection[num_clients];
-            ILeaderWatcher[] leaderWatchers = new ILeaderWatcher[num_clients];
+		[Test]
+		public void testNode4DoesNotBecomeLeaderWhenNonLeader3Closes()
+		{
+			var dir = "/test";
+			var num_clients = 4;
+			clients = new ZooKeeper[num_clients];
+			var elections = new LeaderElection[num_clients];
+			var leaderWatchers = new TestLeaderWatcher[num_clients];
 
-            for (byte i = 0; i < clients.Length; i++)
-            {
-                clients[i] = CreateClient();
-                leaderWatchers[i] = new TestLeaderWatcher(i);
-                elections[i] = new LeaderElection(clients[i], dir, leaderWatchers[i], new[] { i });
-                elections[i].Start();
-            }
+			for (byte i = 0; i < clients.Length; i++)
+			{
+				clients[i] = CreateClient();
+				leaderWatchers[i] = new TestLeaderWatcher((byte)(i + 1)); // Start at 1 so we can check it is set
+				elections[i] = new LeaderElection(clients[i], dir, leaderWatchers[i], new[] { i });
+				elections[i].Start();
+			}
 
-            // Kill 2
-            elections[2].Close();
-            
-            elections[0].Close();
-            elections[1].Close();
-            elections[3].Close();
-            // First one should still leader
-            Assert.AreEqual(0, TestLeaderWatcher.Leader);
-        }
+			// Kill 2
+			elections[2].Close();
+			// First one should still be leader
+			Thread.Sleep(3000);
+			Assert.AreEqual(1, leaderWatchers[0].Leader);
+			Assert.AreEqual(0, leaderWatchers[1].Leader);
+			Assert.AreEqual(0, leaderWatchers[2].Leader);
+			Assert.AreEqual(0, leaderWatchers[3].Leader);
+			elections[0].Close();
+			elections[1].Close();
+			elections[3].Close();
+		}
 	}
 }
+

--- a/src/dotnet/ZooKeeperNet.Recipes.Tests/LeaderElectionTests.cs
+++ b/src/dotnet/ZooKeeperNet.Recipes.Tests/LeaderElectionTests.cs
@@ -71,5 +71,32 @@ namespace ZooKeeperNetRecipes.Tests {
 			}
 			Assert.Pass();
 		}
+
+        [Test]
+	    public void testNode4DoesNotBecomeLeaderWhenNonLeader3Closes()
+	    {
+            string dir = "/test";
+            int num_clients = 4;
+            clients = new ZooKeeper[num_clients];
+            LeaderElection[] elections = new LeaderElection[num_clients];
+            ILeaderWatcher[] leaderWatchers = new ILeaderWatcher[num_clients];
+
+            for (byte i = 0; i < clients.Length; i++)
+            {
+                clients[i] = CreateClient();
+                leaderWatchers[i] = new TestLeaderWatcher(i);
+                elections[i] = new LeaderElection(clients[i], dir, leaderWatchers[i], new[] { i });
+                elections[i].Start();
+            }
+
+            // Kill 2
+            elections[2].Close();
+            
+            elections[0].Close();
+            elections[1].Close();
+            elections[3].Close();
+            // First one should still leader
+            Assert.AreEqual(0, TestLeaderWatcher.Leader);
+        }
 	}
 }


### PR DESCRIPTION
Fixed a bug, with the description below.

With the following configuration:
- Candidate 1
- Candidate 2
- Candidate 3
- Candidate 4

Start them in that order, candidate 1 becomes the leader. If you then kill candidate 3, candidate 4 would become the leader.

I have implemented it as per the documentation "If a client receives a notification that the znode it is watching is gone, then it becomes the new leader in the case that there is no smaller znode". Previously the code became the leader regardless of whether if was the smallest znode.
