### PR TITLE
Fix backoff when connecting to cluster with leader election in progress

### DIFF
--- a/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
+++ b/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
@@ -315,8 +315,6 @@ namespace ZooKeeperNet
 
                     tempClient.EndConnect(ar);
 
-                    zkEndpoints.CurrentEndPoint.SetAsSuccess();
-
                     break;
                 }
                 catch (Exception ex)
@@ -390,6 +388,9 @@ namespace ZooKeeperNet
                 if (len == 0) //server closed the connection...
                 {
                     LOG.Debug("TcpClient connection lost.");
+                    if(zooKeeper.State == ZooKeeper.States.CONNECTING)
+                        zkEndpoints.CurrentEndPoint.SetAsFailure();
+
                     zooKeeper.State = ZooKeeper.States.NOT_CONNECTED;
                     IsConnectionClosedByServer = true;
                     return;
@@ -507,6 +508,7 @@ namespace ZooKeeperNet
         {
             using (var reader = new EndianBinaryReader(EndianBitConverter.Big, new MemoryStream(content), Encoding.UTF8))
             {
+                zkEndpoints.CurrentEndPoint.SetAsSuccess();
                 BinaryInputArchive bbia = BinaryInputArchive.GetArchive(reader);
                 ConnectResponse conRsp = new ConnectResponse();
                 conRsp.Deserialize(bbia, "connect");


### PR DESCRIPTION
When the client attempts to connect to a cluster that's in the process of leader re-election, the TCP connection initially succeeds but is then closed by the ZK node. The current backoff logic treats this as a "success" and resets the backoff, resulting in reconnect attempts without any backoff, and with many clients this can result in a considerable load on the ZK servers at a very critical moment, potentially delaying the re-election and recovery.

The effect can be seen with https://github.com/anttirt/zktestcluster (you'll need Virtualbox and Vagrant) and any client connecting to it using ZooKeeperNet. Set up the cluster (`vagrant up`), connect a client to it and run `vagrant -c ssh //vagrant/restart-leader.sh`. You should see the client attempting many (dozens) of reconnects with no backoff.

This patch delays resetting the backoff until we have a confirmed session on the ZK node.
