### PR TITLE
NullReferenceException

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ src/dotnet/ZooKeeperNet/Generated/*.cs
 src/dotnet/ZooKeeperNet/_Reshaper
 src/dotnet/ZooKeeperNet/bin
 src/dotnet/ZooKeeperNet/obj
+/src/dotnet/packages

--- a/src/dotnet/ZooKeeperNet/ClientConnection.cs
+++ b/src/dotnet/ZooKeeperNet/ClientConnection.cs
@@ -399,8 +399,15 @@ namespace ZooKeeperNet
                 }
                 finally
                 {
-                    producer.Dispose();
-                    consumer.Dispose();
+                    if (null != producer)
+                    {
+                        producer.Dispose();
+                    }
+                    
+                    if (null != consumer)
+                    {
+                        consumer.Dispose();
+                    }
                 }
 
             }

--- a/src/dotnet/ZooKeeperNet/ZooKeeper.cs
+++ b/src/dotnet/ZooKeeperNet/ZooKeeper.cs
@@ -303,7 +303,11 @@
         {
             get
             {
-                return cnxn.SessionId;
+                if (null != cnxn)
+                {
+                    return cnxn.SessionId;
+                }
+                return 0;
             }
         }
 


### PR DESCRIPTION
If an exception occurs in the ClientConnection.ResolveHostToIpAddresses, it will result in NullReferenceException.
