### PR TITLE
fix PublicKeyToken for log4net 1.2.15.0

### DIFF
--- a/src/dotnet/ZooKeeperNet/ZooKeeperNet.csproj
+++ b/src/dotnet/ZooKeeperNet/ZooKeeperNet.csproj
@@ -56,7 +56,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.10.0, Culture=neutral, PublicKeyToken=1b44e1d426115821, processorArchitecture=MSIL">
+    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\lib\log4net.dll</HintPath>
     </Reference>


### PR DESCRIPTION
pull request #34 has upgraded log4net to 1.2.15.0 but did not modify the PublicKeyToken in csproj