### PR TITLE
ZooKeeperNet: SaslAuthenticated events, robustness fixes, and tests

### DIFF
--- a/src/dotnet/ZooKeeperNet.Tests/AbstractZooKeeperTests.cs
+++ b/src/dotnet/ZooKeeperNet.Tests/AbstractZooKeeperTests.cs
@@ -54,9 +54,8 @@ namespace ZooKeeperNet.Tests
             return new ZooKeeper(address, new TimeSpan(0, 0, 0, 10000), watcher);
         }
 
-        protected virtual ZooKeeper CreateClientWithSasl(ISaslClient saslClient)
+        protected virtual ZooKeeper CreateClientWithSasl(IWatcher watcher, ISaslClient saslClient)
         {
-            CountdownWatcher watcher = new CountdownWatcher();
             // "Only" use a 10s session timeout as failed tests can
             // otherwise spin for a very long time in the client's
             // Dispose method.

--- a/src/dotnet/ZooKeeperNet.Tests/AbstractZooKeeperTests.cs
+++ b/src/dotnet/ZooKeeperNet.Tests/AbstractZooKeeperTests.cs
@@ -57,7 +57,10 @@ namespace ZooKeeperNet.Tests
         protected virtual ZooKeeper CreateClientWithSasl(ISaslClient saslClient)
         {
             CountdownWatcher watcher = new CountdownWatcher();
-            return new ZooKeeper("127.0.0.1:2181", new TimeSpan(0, 0, 0, 10000), watcher, saslClient);
+            // "Only" use a 10s session timeout as failed tests can
+            // otherwise spin for a very long time in the client's
+            // Dispose method.
+            return new ZooKeeper("127.0.0.1:2181", new TimeSpan(0, 0, 0, 10), watcher, saslClient);
         }
 
         public class CountdownWatcher : IWatcher

--- a/src/dotnet/ZooKeeperNet.Tests/SaslTests.cs
+++ b/src/dotnet/ZooKeeperNet.Tests/SaslTests.cs
@@ -121,6 +121,7 @@ namespace ZooKeeperNet.Tests
             using (var zk = CreateClientWithSasl(new S22SaslClient()))
             {
                 zk.GetData(name, false, new Stat());
+                zk.Delete(name, -1);
             }
         }
     }

--- a/src/dotnet/ZooKeeperNet.Tests/SaslTests.cs
+++ b/src/dotnet/ZooKeeperNet.Tests/SaslTests.cs
@@ -89,7 +89,7 @@ namespace ZooKeeperNet.Tests
         }
     }
 
-    [TestFixture]
+    [TestFixture, Explicit]
     public class SaslTests : AbstractZooKeeperTests
     {
         [Test]

--- a/src/dotnet/ZooKeeperNet.Tests/SaslTests.cs
+++ b/src/dotnet/ZooKeeperNet.Tests/SaslTests.cs
@@ -24,6 +24,7 @@ namespace ZooKeeperNet.Tests
     using S22.Sasl;
     using System.Net;
     using System.Collections.Generic;
+    using System.Threading;
 
     class S22SaslClient : ISaslClient
     {
@@ -89,24 +90,72 @@ namespace ZooKeeperNet.Tests
         }
     }
 
+    internal class StateWatcher : IWatcher
+    {
+        private EventWaitHandle ewh = new EventWaitHandle(false, EventResetMode.ManualReset);
+
+        private KeeperState waitFor;
+        private IList<KeeperState> observed;
+
+        public StateWatcher(KeeperState waitFor, bool collectObserved = false)
+        {
+            this.waitFor = waitFor;
+            this.observed = collectObserved ? new List<KeeperState>() : null;
+        }
+
+        public void Process(WatchedEvent @event)
+        {
+            if (this.observed != null)
+            {
+                this.observed.Add(@event.State);
+            }
+
+            if (@event.State == waitFor)
+            {
+                ewh.Set();
+            }
+        }
+
+        public bool WaitSignaled(int ms)
+        {
+            return ewh.WaitOne(ms);
+        }
+
+        public IList<KeeperState> Observed 
+        { 
+            get 
+            { 
+                return observed;
+            }
+        }
+    }
+
     [TestFixture, Explicit]
     public class SaslTests : AbstractZooKeeperTests
     {
+        private static readonly int maxWaitMs = 250;
+
         [Test]
         public void testSasl()
         {
             string name = "/" + Guid.NewGuid() + "sasltest";
 
-            using (var zk = CreateClientWithSasl(new S22SaslClient()))
+            var authWatcher = new StateWatcher(KeeperState.SaslAuthenticated);
+            using (var zk = CreateClientWithSasl(authWatcher, new S22SaslClient()))
             {
+                Assert.IsTrue(authWatcher.WaitSignaled(maxWaitMs));
+                
                 List<ACL> acl = new List<ACL>();
                 acl.Add(new ACL(Perms.ALL, new ZKId("sasl", "bob")));
 
                 Assert.AreEqual(name, zk.Create(name, new byte[0], acl, CreateMode.Persistent));
             }
 
-            using (var zk = CreateClient())
+            var connWatcher = new StateWatcher(KeeperState.SyncConnected);
+            using (var zk = CreateClient(connWatcher))
             {
+                Assert.IsTrue(connWatcher.WaitSignaled(maxWaitMs));
+
                 try
                 {
                     zk.GetData(name, false, new Stat());
@@ -118,8 +167,11 @@ namespace ZooKeeperNet.Tests
                 }
             }
 
-            using (var zk = CreateClientWithSasl(new S22SaslClient()))
+            var authWatcher2 = new StateWatcher(KeeperState.SaslAuthenticated);
+            using (var zk = CreateClientWithSasl(authWatcher2, new S22SaslClient()))
             {
+                Assert.IsTrue(authWatcher2.WaitSignaled(maxWaitMs));
+
                 zk.GetData(name, false, new Stat());
                 zk.Delete(name, -1);
             }

--- a/src/dotnet/ZooKeeperNet/KeeperState.cs
+++ b/src/dotnet/ZooKeeperNet/KeeperState.cs
@@ -23,6 +23,8 @@
         Disconnected = 0,
         NoSyncConnected = 1,
         SyncConnected = 3,
+        AuthFailed = 4,
+        SaslAuthenticated = 6,
         Expired = -112
     }
 }

--- a/src/dotnet/ZooKeeperNet/ZooKeeper.cs
+++ b/src/dotnet/ZooKeeperNet/ZooKeeper.cs
@@ -198,6 +198,16 @@
                 return this != CLOSED && this != AUTH_FAILED;
             }
 
+            public bool IsConnected()
+            {
+                return this == CONNECTED; // || this == CONNECTEDREADONLY
+            }
+
+            public bool IsAuthFailed()
+            {
+                return this == AUTH_FAILED;
+            }
+
             public bool Equals(States other)
             {
                 if (ReferenceEquals(null, other)) return false;


### PR DESCRIPTION
Hi @ewhauser,

This is a follow-up to https://github.com/ewhauser/zookeeper/pull/38 which adds a few missing pieces and tightens a few knots.

Besides the addition of `SaslAuthenticated` events and fixes, which should probably go in, I have a question:

The SASL tests now use a much shorter session timeout than the others; 10s, down from 10000s, to avoid tests spinning "forever" in `Dispose` on failure.  But I'm now wondering: is that large timeout intentional—or just a mix-up between milliseconds and seconds?  (They've been there for a long time; the history does not make it entirely obvious.)

What do you think?

Cheers, -D