### PR TITLE
ZooKeeperNet: Assorted cleanups & fixes

### DIFF
--- a/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
+++ b/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
@@ -533,7 +533,7 @@ namespace ZooKeeperNet
             {
                 if (!ClientConnection.DisableAutoWatchReset && (!zooKeeper.DataWatches.IsEmpty() || !zooKeeper.ExistWatches.IsEmpty() || !zooKeeper.ChildWatches.IsEmpty()))
                 {
-                    var sw = new SetWatches(lastZxid, zooKeeper.DataWatches, zooKeeper.ExistWatches, zooKeeper.ChildWatches);
+                    var sw = new SetWatches(lastZxid, prependChroot(zooKeeper.DataWatches), prependChroot(zooKeeper.ExistWatches), prependChroot(zooKeeper.ChildWatches));
                     var h = new RequestHeader();
                     h.Type = (int)OpCode.SetWatches;
                     h.Xid = -8;
@@ -735,6 +735,29 @@ namespace ZooKeeperNet
                 p.watchRegistration.Register(p.replyHeader.Err);
 
             p.Finished = true;
+        }
+
+        private IEnumerable<string> prependChroot(IEnumerable<string> paths)
+        {
+            string chrootPath = conn.ChrootPath;
+
+            if (string.IsNullOrEmpty(chrootPath))
+            {
+                return paths;
+            }
+
+            return paths.Select(clientPath =>
+            {
+                // handle clientPath = "/"
+                if (clientPath.Length == 1)
+                {
+                    return chrootPath;
+                }
+                else
+                {
+                    return chrootPath + clientPath;
+                }
+            });
         }
 
         private int isDisposed = 0;

--- a/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
+++ b/src/dotnet/ZooKeeperNet/ClientConnectionRequestProducer.cs
@@ -138,6 +138,10 @@ namespace ZooKeeperNet
                         if(conn.IsClosed || closing)
                             break;
 
+                        // Clean up the previous TCP connection if needed, and
+                        // reset the 'client' field.
+                        Cleanup();
+
                         StartConnect();
                         lastSend = now;
                     }
@@ -250,8 +254,8 @@ namespace ZooKeeperNet
 
         private void Cleanup()
         {
-            Cleanup(client);
-            client = null;
+            TcpClient tcpClient = Interlocked.Exchange(ref client, null);
+            Cleanup(tcpClient);
         }
 
         private void StartConnect()
@@ -346,8 +350,8 @@ namespace ZooKeeperNet
                 throw KeeperException.Create(KeeperException.Code.CONNECTIONLOSS);
             }
 
-            client = tempClient;
-            client.GetStream().BeginRead(incomingBuffer, 0, incomingBuffer.Length, ReceiveAsynch, incomingBuffer);
+            Interlocked.Exchange(ref client, tempClient);
+            client.GetStream().BeginRead(incomingBuffer, 0, incomingBuffer.Length, ReceiveAsynch, Tuple.Create(client, incomingBuffer));
             PrimeConnection();
         }
 
@@ -374,17 +378,27 @@ namespace ZooKeeperNet
             int len = 0;
             try
             {
-                if (client == null)
-                    return;
-                NetworkStream stream = client.GetStream();
+                Tuple<TcpClient, byte[]> state = (Tuple<TcpClient, byte[]>)ar.AsyncState;
+                TcpClient asyncClient = state.Item1;
+                byte[] bData = state.Item2;
+
+                NetworkStream stream = asyncClient.GetStream();
 
                 try
                 {
                     len = stream.EndRead(ar);
                 }
-                catch
+                catch (Exception ex)
                 {
+                    LOG.Error(ex);
                 }
+
+                if (Interlocked.CompareExchange(ref client, asyncClient, asyncClient) != asyncClient)
+                {
+                    // there was a reconnect in the meantime on the sender thread; do nothing
+                    return;
+                }
+
                 if (len == 0) //server closed the connection...
                 {
                     LOG.Debug("TcpClient connection lost.");
@@ -395,7 +409,7 @@ namespace ZooKeeperNet
                     IsConnectionClosedByServer = true;
                     return;
                 }
-                byte[] bData = (byte[])ar.AsyncState;
+                
                 recvCount++;
 
                 if (bData == incomingBuffer) // if bData is incoming then surely it is a length information
@@ -405,7 +419,7 @@ namespace ZooKeeperNet
                     // get the length information from the stream
                     juteBuffer = new byte[ReadLength(bData)];
                     // try getting other info from the stream
-                    stream.BeginRead(juteBuffer, 0, juteBuffer.Length, ReceiveAsynch, juteBuffer);
+                    stream.BeginRead(juteBuffer, 0, juteBuffer.Length, ReceiveAsynch, Tuple.Create(asyncClient, juteBuffer));
                 }
                 else // not an incoming buffer then it is surely a zookeeper process information
                 {
@@ -414,19 +428,19 @@ namespace ZooKeeperNet
                         // haven't been initialized so read the authentication negotiation result
                         ReadConnectResult(bData);
                         // reading length information
-                        stream.BeginRead(incomingBuffer, 0, incomingBuffer.Length, ReceiveAsynch, incomingBuffer);
+                        stream.BeginRead(incomingBuffer, 0, incomingBuffer.Length, ReceiveAsynch, Tuple.Create(asyncClient, incomingBuffer));
                     }
                     else
                     {
                         currentLen += len;
                         if (juteBuffer.Length > currentLen) // stream haven't been completed so read any left bytes
-                            stream.BeginRead(juteBuffer, currentLen, juteBuffer.Length - currentLen, ReceiveAsynch, juteBuffer);
+                            stream.BeginRead(juteBuffer, currentLen, juteBuffer.Length - currentLen, ReceiveAsynch, Tuple.Create(asyncClient, juteBuffer));
                         else
                         {
                             // stream is complete so read the response
                             ReadResponse(bData);
                             // everything is fine, now read the stream again for length information
-                            stream.BeginRead(incomingBuffer, 0, incomingBuffer.Length, ReceiveAsynch, incomingBuffer);
+                            stream.BeginRead(incomingBuffer, 0, incomingBuffer.Length, ReceiveAsynch, Tuple.Create(asyncClient, incomingBuffer));
                         }
                     }
                 }

--- a/src/dotnet/ZooKeeperNet/Packet.cs
+++ b/src/dotnet/ZooKeeperNet/Packet.cs
@@ -35,7 +35,6 @@ namespace ZooKeeperNet
         private string serverPath;
         internal ReplyHeader replyHeader;
         internal IRecord response;
-        private int finished;
         internal ZooKeeper.WatchRegistration watchRegistration;
         internal readonly byte[] data;
         public readonly DateTime DateCreated;
@@ -109,7 +108,7 @@ namespace ZooKeeperNet
 
             sb.Append("  clientPath:").Append(clientPath);
             sb.Append("  serverPath:").Append(serverPath);
-            sb.Append("    finished:").Append(finished);
+            sb.Append("    finished:").Append(mreslim.IsSet);
             sb.Append("     header::").Append(header);
             sb.Append("replyHeader::").Append(replyHeader);
             sb.Append("    request::").Append(request);

--- a/src/dotnet/ZooKeeperNet/ZKPaths.cs
+++ b/src/dotnet/ZooKeeperNet/ZKPaths.cs
@@ -151,7 +151,7 @@ namespace ZooKeeperNet
                     {
                         zookeeper.Create(subPath, new byte[0], Ids.OPEN_ACL_UNSAFE, CreateMode.Persistent);
                     }
-                    catch (KeeperException.NodeExistsException e)
+                    catch (KeeperException.NodeExistsException)
                     {
                         // ignore... someone else has created it since we checked
                     }


### PR DESCRIPTION
Hi @ewhauser,

The attached patch include a few cleanups, and fixes for problems encountered in production.

The cleanups are trivial, but they make recent versions of the C# compiler happy.

Patch nr. 3 is for a race condition which can happen under load.  The existing code was checking for a non-null (TCP) `client` field, but that is not sufficient—as the non-null `client` might be a different one by the time the asynchronous callback executes, causing "interesting" mix-ups. I also tried to use atomic operations for reference values which are observed by both threads; let me know if that muddies the waters too much.

As for patch nr. 4, it is basically a .NET transcription of [ZOOKEEPER-961](https://issues.apache.org/jira/browse/ZOOKEEPER-961), where it was discovered that watches were not correctly reestablished for "chrooted" clients.

There you are.  I put the four patches in a single "pull request" not to overload you with notifications and reviews—but let me know if you would prefer me to move some of them to dedicated request(s).

Cheers, -D
